### PR TITLE
Minor changes to JSON resources to address inconsistencies

### DIFF
--- a/src/generated/resources/data/ancient_aether/recipes/valkyrum_gloves.json
+++ b/src/generated/resources/data/ancient_aether/recipes/valkyrum_gloves.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "key": {
+    "#": {
+      "item": "ancient_aether:valkyrum"
+    }
+  },
+  "pattern": [
+    "# #"
+  ],
+  "result": {
+    "item": "ancient_aether:valkyrum_gloves"
+  },
+  "show_notification": true
+}

--- a/src/main/resources/assets/aether/models/item/valkyrie_chestplate.json
+++ b/src/main/resources/assets/aether/models/item/valkyrie_chestplate.json
@@ -1,6 +1,0 @@
-{
-  "parent": "minecraft:item/generated",
-  "textures": {
-    "layer0": "ancient_aether:item/valkyrum_chestplate"
-  }
-}


### PR DESCRIPTION
While making a modpack with Ancient Aether, I noticed two odd inconsistencies:
1. The base Aether mod's Valkyrie Chestplate item has Ancient Aether's Valkyrum Chestplate texture.
2. Valkyrum Gloves do not have a crafting recipe, but all other Valkyrum gear follows Aether's crafting pattern.

The Valkyrum Gloves recipe should be generated, but the recipes detailed in `AncientAetherRecipeData.java` didn't seem to line up with the files in `src/generated/resources/data`, so I assumed some recipes were written manually and followed suit.