### PR TITLE
Backport Aether 1.5 compat (1.20.1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'org.moddingx.modgradle.sourcejar' version '4.0.4' apply false
 }
 
-version = '0.9.5'
+version = '0.9.8'
 group = 'net.builderdog.ancient_aether'
 archivesBaseName = 'ancient_aether'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,9 +11,9 @@ mc_version=1.20.1
 neoforge_version=47.1.70
 mappings=2023.08.20-1.20.1
 
-aether_version=1.20.1-1.4.2-neoforge
-nitrogen_version=1.20.1-1.0.7-neoforge
-cumulus_version=1.20.1-0.1.2-neoforge
+aether_version=1.20.1-1.5.1-neoforge
+nitrogen_version=1.20.1-1.0.11-neoforge
+cumulus_version=1.20.1-1.0.1-neoforge
 terrablender_version=1.20.1-3.0.0.169
 curios_version=5.3.2+1.20.1
 aeroblender_version=4756779

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.daemon=false
 # Mod
 mod_id=ancient_aether
 mod_name=Ancient Aether
-mod_version=0.9.5
+mod_version=0.9.8
 mc_version=1.20.1
 neoforge_version=47.1.70
 mappings=2023.08.20-1.20.1

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -4,7 +4,7 @@ license = "Assets: All Rights Reserved; Code: LGPL-3.0"
 
 [[mods]]
 modId="ancient_aether"
-version="0.9.5"
+version="0.9.8"
 displayName="Ancient Aether"
 logoFile="ancient_aether.png"
 credits= "Contributors: TunefulTurnip, Zepalesque | Translators: unroman, taizazanek, YuJianghan"

--- a/src/main/resources/packs/ancient_aether_worldgen_overrides/data/aether/worldgen/structure/gold_dungeon.json
+++ b/src/main/resources/packs/ancient_aether_worldgen_overrides/data/aether/worldgen/structure/gold_dungeon.json
@@ -2,8 +2,14 @@
   "type": "aether:gold_dungeon",
   "belowTerrain": 20,
   "biomes": "#aether:has_gold_dungeon",
+  "islandFoliage": "aether:gold_dungeon_island_foliage",
   "minY": 96,
   "rangeY": 96,
+  "processor_settings": {
+    "boss_room_processors": "aether:gold_boss_room",
+    "island_processors": "aether:gold_island",
+    "tunnel_processors": "aether:gold_tunnel"
+  },
   "spawn_overrides": {
     "aether_aerwhale": {
       "bounding_box": "full",
@@ -55,5 +61,14 @@
     }
   },
   "step": "surface_structures",
+  "stubFoliage": {
+    "feature": "aether:golden_oak_tree",
+    "placement": [
+      {
+        "type": "minecraft:rarity_filter",
+        "chance": 64
+      }
+    ]
+  },
   "stubcount": 8
 }

--- a/src/main/resources/packs/ancient_aether_worldgen_overrides/data/aether/worldgen/structure/silver_dungeon.json
+++ b/src/main/resources/packs/ancient_aether_worldgen_overrides/data/aether/worldgen/structure/silver_dungeon.json
@@ -5,6 +5,11 @@
   "biomes": "#aether:has_silver_dungeon",
   "maxY": 180,
   "minY": 48,
+  "processor_settings": {
+    "boss_room_processors": "aether:silver_boss_room",
+    "floor_processors": "aether:silver_floor",
+    "generic_room_processors": "aether:silver_room"
+  },
   "rangeY": 128,
   "spawn_overrides": {
     "aether_aerwhale": {


### PR DESCRIPTION
Hi! As you're aware, Aether 1.5 introduced an incompatibility with Ancient Aether which you fixed with your 1.20.4 release.

As Aether 1.5 is also available for 1.20.1 and this crash prevents creating or loading worlds, I figured a hotfix for this version would be nice to have, so I've backported 2ca8f1baa46167bbc6d22e1347b2855c5c795916 (:
This PR already bumps the version number. (Some version number bumps seen on modrinth/cf seem to be missing from the repo even though the fixes from those bumps is there)
To merge, you just have to make a new branch starting from dee944d4f203716ae6988d5c348a82452da30745 and have this PR point at that branch instead. 

Fixes #205
Fixes #206 
Fixes #207 
Fixes #208

I wanted to quickly make a PR for 1.19.4 (brancing off of 2644ab0b9b646aa027694b97aa80ac9ada5ea152) as well but that additionally runs into some compilation issues for the Ancient Guardian when updating the Aether deps and I don't have the time to dive into that right now.