### PR TITLE
Fix broken tags in compat packs

### DIFF
--- a/src/main/resources/packs/compatibility/aether_redux/data/ancient_aether/tags/worldgen/biome/has_structure/holystone_ruin.json
+++ b/src/main/resources/packs/compatibility/aether_redux/data/ancient_aether/tags/worldgen/biome/has_structure/holystone_ruin.json
@@ -1,4 +1,5 @@
 {
+  "values": [],
   "remove": [
     "aether_redux:gilded_groves"
   ]

--- a/src/main/resources/packs/compatibility/aether_redux/data/ancient_aether/tags/worldgen/biome/is_wyndcaps.json
+++ b/src/main/resources/packs/compatibility/aether_redux/data/ancient_aether/tags/worldgen/biome/is_wyndcaps.json
@@ -1,6 +1,6 @@
 {
   "values": [
-    "aether_redux:frosted_tundra",
-    "aether_redux:glacial_taiga"
+    "aether_redux:frosted_forests",
+    "aether_redux:glacial_tundra"
   ]
 }

--- a/src/main/resources/packs/compatibility/deep_aether/data/ancient_aether/tags/worldgen/biome/has_structure/holystone_ruin.json
+++ b/src/main/resources/packs/compatibility/deep_aether/data/ancient_aether/tags/worldgen/biome/has_structure/holystone_ruin.json
@@ -1,4 +1,5 @@
 {
+  "values": [],
   "remove": [
     "deep_aether:golden_grove"
   ]


### PR DESCRIPTION
### Issues Fixed
- Fixes #210
- holystone ruins had some tag loading errors due to not having a "values" key. 