### PR TITLE
Fix ambrosium campfires not being able to be turned back on (1.20.1)

### DIFF
--- a/src/generated/resources/.cache/29b9f006c49695456215b064cedbca3a50869730
+++ b/src/generated/resources/.cache/29b9f006c49695456215b064cedbca3a50869730
@@ -1,4 +1,4 @@
-// 1.20.1	2024-05-12T12:27:04.0745838	Tags for minecraft:block mod id ancient_aether
+// 1.20.1	2025-01-27T14:47:54.734159	Tags for minecraft:block mod id ancient_aether
 f0714fea3e89b69a7a6a6c729a028562bc0bd412 data/aether/tags/blocks/aerclouds.json
 c2354d6e9e1ad7d82a74dc026cfd3d3925683c7c data/aether/tags/blocks/aether_island_blocks.json
 c4903e6639b04406c020546d7cf2b0d7043443a7 data/aether/tags/blocks/aether_portal_blacklist.json
@@ -40,6 +40,7 @@ db284a03b1ab6c6d5cef25fdf5349b6851a7f516 data/forge/tags/blocks/fence_gates/wood
 90d07b81e26e07844cfff7b76febf1a2861b273f data/forge/tags/blocks/ore_rates/singular.json
 bd87b848151f5ba65e717dd3f25eb88e0ba9fc12 data/forge/tags/blocks/storage_blocks.json
 bd87b848151f5ba65e717dd3f25eb88e0ba9fc12 data/minecraft/tags/blocks/beacon_base_blocks.json
+030f441b28ab2ba2ef3bc83435b765210b31fd49 data/minecraft/tags/blocks/campfires.json
 caebe6e6db3d95c4715e1f9ce91ddb56aa9fc8d7 data/minecraft/tags/blocks/ceiling_hanging_signs.json
 7c35812c648b1a270ac4d21880807c07fe5155c8 data/minecraft/tags/blocks/climbable.json
 46112be4b3c309ebaf2995cb2d290508e8f64905 data/minecraft/tags/blocks/dragon_immune.json

--- a/src/generated/resources/data/minecraft/tags/blocks/campfires.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/campfires.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "ancient_aether:ambrosium_campfire"
+  ]
+}

--- a/src/main/java/net/builderdog/ancient_aether/data/generators/tags/AncientAetherBlockTagData.java
+++ b/src/main/java/net/builderdog/ancient_aether/data/generators/tags/AncientAetherBlockTagData.java
@@ -426,6 +426,9 @@ public class AncientAetherBlockTagData extends BlockTagsProvider {
         tag(BlockTags.CLIMBABLE).add(
                 AncientAetherBlocks.GRAPE_VINE.get()
         );
+        tag(BlockTags.CAMPFIRES).add(
+                AncientAetherBlocks.AMBROSIUM_CAMPFIRE.get()
+        );
         tag(BlockTags.MINEABLE_WITH_AXE).add(
                 AncientAetherBlocks.SKY_GRASS.get(),
                 AncientAetherBlocks.HIGHSPROOT_LOG.get(),


### PR DESCRIPTION
Will be making a PR to the master branch shortly as well.

Fixes #213 because fsr that behaviour checks the block tag first.